### PR TITLE
Drop OpenMQ ghprbhook

### DIFF
--- a/otterdog/eclipse-ee4j.jsonnet
+++ b/otterdog/eclipse-ee4j.jsonnet
@@ -1991,14 +1991,6 @@ orgs.newOrg('eclipse-ee4j') {
           ],
           secret: "********",
         },
-        orgs.newRepoWebhook('https://ci.eclipse.org/openmq/ghprbhook/') {
-          content_type: "json",
-          events+: [
-            "issue_comment",
-            "pull_request",
-            "push"
-          ],
-        },
         orgs.newRepoWebhook('https://ci.eclipse.org/openmq/github-webhook/') {
           content_type: "json",
           events+: [


### PR DESCRIPTION
I could only track the second one (`github-webhook`) to be consumed here: https://ci.eclipse.org/openmq/job/openmq-build-and-test-using-jenkinsfile/indexing/events.

But not this one.