### PR TITLE
Drop OpenMQ zenhub webhook

### DIFF
--- a/otterdog/eclipse-ee4j.jsonnet
+++ b/otterdog/eclipse-ee4j.jsonnet
@@ -1975,22 +1975,6 @@ orgs.newOrg('eclipse-ee4j') {
         default_workflow_permissions: "write",
       },
       webhooks: [
-        orgs.newRepoWebhook('https://webhook.zenhub.io/webhook/github/v1/55c23ea767d046c00d') {
-          content_type: "json",
-          events+: [
-            "issue_comment",
-            "issues",
-            "label",
-            "member",
-            "milestone",
-            "pull_request",
-            "pull_request_review",
-            "pull_request_review_comment",
-            "repository",
-            "team_add"
-          ],
-          secret: "********",
-        },
         orgs.newRepoWebhook('https://ci.eclipse.org/openmq/github-webhook/') {
           content_type: "json",
           events+: [


### PR DESCRIPTION
I do not recall for OpenMQ to ever use zenhub.

Please let me know if anything like [Remove ZenHub from Adoptium GitHub](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3302) is needed to be performed also for OpenMQ.