### PR TITLE
Switch main branch in soteria

### DIFF
--- a/otterdog/eclipse-ee4j.jsonnet
+++ b/otterdog/eclipse-ee4j.jsonnet
@@ -2196,7 +2196,7 @@ orgs.newOrg('eclipse-ee4j') {
     },
     orgs.newRepo('soteria') {
       allow_merge_commit: true,
-      default_branch: "master",
+      default_branch: "main",
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       description: "Soteria, a Jakarta Security implementation",


### PR DESCRIPTION
Hi @arjantijms,

I'm not sure how this will work if I open this PR against [soteria](https://github.com/eclipse-ee4j/soteria/) (as I'm not commiter there).
Hope your approval will have the power to move it forward if you agree.

As a lot of PRs in the project are merged to `main`, the 4.0.0 release is done from `main` as well - perhaps the repository default branch could be switched there? From the community POV I find it a bit confusing with current, stalled, outdated `master` to be the default.

Please consider such change.