### PR TITLE
Switch main branch in grizzly

### DIFF
--- a/otterdog/eclipse-ee4j.jsonnet
+++ b/otterdog/eclipse-ee4j.jsonnet
@@ -1037,7 +1037,7 @@ orgs.newOrg('ee4j', 'eclipse-ee4j') {
     orgs.newRepo('grizzly') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      default_branch: "master",
+      default_branch: "main",
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       description: "Grizzly",
@@ -1085,7 +1085,7 @@ orgs.newOrg('ee4j', 'eclipse-ee4j') {
           requires_status_checks: false,
           requires_strict_status_checks: true,
         },
-        orgs.newBranchProtectionRule('master') {
+        orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
           requires_status_checks: false,
           requires_strict_status_checks: true,


### PR DESCRIPTION
Target of some latest PRs, like
- https://github.com/eclipse-ee4j/grizzly/pull/2209
- https://github.com/eclipse-ee4j/grizzly/pull/2203

suggests that `main` is the new default branch in repository.

@anajosep, please check and approve or reject this PR.
Or perhaps @arjantijms or @pnicolucci could do that as well.