### PR TITLE
Mojarra: default branch main, protect main/5.0/tck-status

### DIFF
--- a/otterdog/eclipse-ee4j.jsonnet
+++ b/otterdog/eclipse-ee4j.jsonnet
@@ -1965,7 +1965,7 @@ orgs.newOrg('ee4j', 'eclipse-ee4j') {
     },
     orgs.newRepo('mojarra') {
       allow_merge_commit: true,
-      default_branch: "master",
+      default_branch: "main",
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       description: "Mojarra, a Jakarta Faces implementation",
@@ -2009,7 +2009,7 @@ orgs.newOrg('ee4j', 'eclipse-ee4j') {
         },
       ],
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('master') {
+        orgs.newBranchProtectionRule('main') {
           required_approving_review_count: null,
           requires_pull_request: false,
           requires_status_checks: false,
@@ -2034,6 +2034,18 @@ orgs.newOrg('ee4j', 'eclipse-ee4j') {
           requires_strict_status_checks: true,
         },
         orgs.newBranchProtectionRule('4.0') {
+          required_approving_review_count: null,
+          requires_pull_request: false,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+        orgs.newBranchProtectionRule('5.0') {
+          required_approving_review_count: null,
+          requires_pull_request: false,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+        orgs.newBranchProtectionRule('tck-status') {
           required_approving_review_count: null,
           requires_pull_request: false,
           requires_status_checks: false,


### PR DESCRIPTION
Aligns the Mojarra branch layout with jakartaee/faces: `main` is the current release line (4.1), `5.0` is the development line, `4.0` stays as it is.

`4.1` has already been renamed to `main`, so this points the default branch at it and moves the branch protection rule along.

`master` (5.0.0-SNAPSHOT) still has to become `5.0`. Dropping the `master` protection rule and moving the default off it is exactly what lets the project carry out that rename itself, so no webmaster action is needed here.

Also protects `tck-status`, the orphan branch the release pipeline publishes its TCK validation records to.

Every rule keeps the shape already in use on this repo — no required pull request, no required reviews — so they block force-pushes and deletion without changing how committers push. The release pipeline pushes to `tck-status` as a plain fast-forward and is unaffected.

Refs https://github.com/eclipse-ee4j/mojarra/issues/5615

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 5)
